### PR TITLE
Remove obsolete MSVC compiler option

### DIFF
--- a/libusb/config.cmake
+++ b/libusb/config.cmake
@@ -33,7 +33,6 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
 	)
 elseif(MSVC)
 	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-	append_compiler_flags(/Wp64)
 endif()
 
 check_include_files(sys/timerfd.h USBI_TIMERFD_AVAILABLE)


### PR DESCRIPTION
https://docs.microsoft.com/en-us/cpp/build/reference/wp64-detect-64-bit-portability-issues?view=vs-2019
>If you use the /Wp64 compiler option on the command line, the compiler issues Command-Line Warning D9002. Instead of using this option and keyword to detect 64-bit portability issues, use a MSVC compiler that targets a 64-bit platform and specify the /W4 option.